### PR TITLE
DB Schema Refactor

### DIFF
--- a/hub/am/main.go
+++ b/hub/am/main.go
@@ -7,10 +7,7 @@ import (
 
 func main() {
 	db := DBInit()
-	err := db.AutoMigrate(&ApiKey{})
-	if err != nil {
-		log.Fatalf("Error: %s", err.Error())
-	}
+	var err error
 	err = db.AutoMigrate(&User{})
 	if err != nil {
 		log.Fatalf("Error: %s", err.Error())
@@ -23,7 +20,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error: %s", err.Error())
 	}
-	err = db.AutoMigrate(&Session{})
+	err = db.AutoMigrate(&SessionSelenium{})
 	if err != nil {
 		log.Fatalf("Error: %s", err.Error())
 	}

--- a/hub/am/models.go
+++ b/hub/am/models.go
@@ -28,19 +28,6 @@ func DBInit() *gorm.DB {
 	return db
 }
 
-type Tabler interface {
-	TableName() string
-}
-
-// Row from api_keys database table. Only currently valid Key will exist
-type ApiKey struct {
-	Key string `gorm:"primaryKey"`
-}
-
-func (ApiKey) TableName() string {
-	return "api_keys"
-}
-
 // User
 type User struct {
 	Username string `gorm:"primaryKey"`
@@ -51,7 +38,7 @@ func (User) TableName() string {
 	return "users"
 }
 
-// User to API Key relations. Invalidated keys will also exist here
+// User to API Key relations. Only valid keys stored
 type UserKey struct {
 	Username string `gorm:"primaryKey"`
 	Key      string `gorm:"primaryKey"`
@@ -77,8 +64,7 @@ func (Event) TableName() string {
 	return "events"
 }
 
-// Session ID to test Id mapping
-type Session struct {
+type SessionSelenium struct {
 	SessionId string `gorm:"primaryKey"`
 	TestId    int64
 	Time      int64
@@ -87,8 +73,8 @@ type Session struct {
 	Message   string
 }
 
-func (Session) TableName() string {
-	return "sessions"
+func (SessionSelenium) TableName() string {
+	return "sessions_selenium"
 }
 
 /// Session Id to Test Id mapping

--- a/hub/fe/handlers.go
+++ b/hub/fe/handlers.go
@@ -206,7 +206,7 @@ func TestSessionHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	testId, _ := strconv.ParseInt(vars["testId"], 10, 64)
 
-	var sessions []Session
+	var sessions []SessionSelenium
 	db.Where("test_id = ?", testId).Order("time DESC").Find(&sessions)
 
 	TemplateExec(w, "testsession.html", map[string]interface{}{

--- a/hub/fe/models.go
+++ b/hub/fe/models.go
@@ -28,19 +28,6 @@ func DBInit() *gorm.DB {
 	return db
 }
 
-type Tabler interface {
-	TableName() string
-}
-
-// Row from api_keys database table. Only currently valid Key will exist
-type ApiKey struct {
-	Key string `gorm:"primaryKey"`
-}
-
-func (ApiKey) TableName() string {
-	return "api_keys"
-}
-
 // User
 type User struct {
 	Username string `gorm:"primaryKey"`
@@ -51,7 +38,7 @@ func (User) TableName() string {
 	return "users"
 }
 
-// User to API Key relations. Invalidated keys will also exist here
+// User to API Key relations. Only valid keys stored
 type UserKey struct {
 	Username string `gorm:"primaryKey"`
 	Key      string `gorm:"primaryKey"`
@@ -77,8 +64,7 @@ func (Event) TableName() string {
 	return "events"
 }
 
-// Session ID to test Id mapping
-type Session struct {
+type SessionSelenium struct {
 	SessionId string `gorm:"primaryKey"`
 	TestId    int64
 	Time      int64
@@ -87,8 +73,8 @@ type Session struct {
 	Message   string
 }
 
-func (Session) TableName() string {
-	return "sessions"
+func (SessionSelenium) TableName() string {
+	return "sessions_selenium"
 }
 
 /// Session Id to Test Id mapping

--- a/hub/proxse/main.go
+++ b/hub/proxse/main.go
@@ -145,7 +145,7 @@ func ProxyReverseHandlerSessionSetup(proxy *httputil.ReverseProxy) func(
 			log.Printf("\tError in getting New SessionId: %s", err.Error())
 		} else {
 			// TODO get current test Id
-			db.Create(&Session{
+			db.Create(&SessionSelenium{
 				Time:      time.Now().Unix(),
 				TestId:    testId,
 				SessionId: sessId,

--- a/hub/proxse/models.go
+++ b/hub/proxse/models.go
@@ -28,19 +28,6 @@ func DBInit() *gorm.DB {
 	return db
 }
 
-type Tabler interface {
-	TableName() string
-}
-
-// Row from api_keys database table. Only currently valid Key will exist
-type ApiKey struct {
-	Key string `gorm:"primaryKey"`
-}
-
-func (ApiKey) TableName() string {
-	return "api_keys"
-}
-
 // User
 type User struct {
 	Username string `gorm:"primaryKey"`
@@ -51,7 +38,7 @@ func (User) TableName() string {
 	return "users"
 }
 
-// User to API Key relations. Invalidated keys will also exist here
+// User to API Key relations. Only valid keys stored
 type UserKey struct {
 	Username string `gorm:"primaryKey"`
 	Key      string `gorm:"primaryKey"`
@@ -77,8 +64,7 @@ func (Event) TableName() string {
 	return "events"
 }
 
-// Session ID to test Id mapping
-type Session struct {
+type SessionSelenium struct {
 	SessionId string `gorm:"primaryKey"`
 	TestId    int64
 	Time      int64
@@ -87,8 +73,8 @@ type Session struct {
 	Message   string
 }
 
-func (Session) TableName() string {
-	return "sessions"
+func (SessionSelenium) TableName() string {
+	return "sessions_selenium"
 }
 
 /// Session Id to Test Id mapping

--- a/hub/proxse/utils.go
+++ b/hub/proxse/utils.go
@@ -31,7 +31,7 @@ func KeyIsValid(key string) bool {
 	if !ok || time.Now().Unix()-entry.time > int64(ttl) {
 		// refresh cache
 		exist := false
-		_ = db.Model(&ApiKey{}).
+		_ = db.Model(&UserKey{}).
 			Select("count(*) > 0").
 			Where("key = ?", key).
 			Find(&exist).
@@ -72,11 +72,11 @@ func KeyIsValidForSess(key string, sessId string) bool {
 	if !ok || time.Now().Unix()-entry.Time > int64(ttl) {
 		// refresh cache
 		var result bool
-		err := db.Table("sessions").
+		err := db.Table("sessions_selenium").
 			Select("COUNT(*) > 0").
-			Joins("JOIN test_sessions ON sessions.test_id = test_sessions.test_id").
-			Where("sessions.session_id = ?", sessId).
-			Where("sessions.valid = ?", true).
+			Joins("JOIN test_sessions ON sessions_selenium.test_id = test_sessions.test_id").
+			Where("sessions_selenium.session_id = ?", sessId).
+			Where("sessions_selenium.valid = ?", true).
 			Where("test_sessions.key = ?", key).
 			Where("test_sessions.current = ?", true).
 			Find(&result).Error
@@ -127,7 +127,7 @@ func KeyMakeValidForSess(testId int64, key string, sessId string, proj string,
 		Valid: true,
 	}
 	ksessCache[StringPair{key, sessId}] = cacheEntry
-	entry := Session{
+	entry := SessionSelenium{
 		Time: cacheEntry.Time,
 		TestId: testId,
 		SessionId: sessId,
@@ -148,7 +148,7 @@ func KeyMakeInvalidForSess(key string, sessId string) error {
 	// invalidate in cache
 	ksessCache[StringPair{key, sessId}] = KSessCacheEntry{0, false}
 	// invalidate in db
-	err := db.Model(&Session{}).
+	err := db.Model(&SessionSelenium{}).
 		Where("session_id = ?", sessId).
 		Update("valid", false).
 		Error


### PR DESCRIPTION
- Got rid of the `api_keys` table
- `users_keys` table only contains entries with currently valid api keys
- adapted and tested `proxse` and `fe` with these changes.